### PR TITLE
fix IE8 issue. window.scrollTo in IE8 is not a function, it's an object.

### DIFF
--- a/modules/useStandardScroll.js
+++ b/modules/useStandardScroll.js
@@ -30,8 +30,8 @@ export default function useStandardScroll(createHistory) {
   function updateScroll({ key }) {
     currentKey = key
 
-    const scrollPosition = getScrollPosition() || [ 0, 0 ]
-    window.scrollTo(...scrollPosition)
+    const [ x, y ] = getScrollPosition() || [ 0, 0 ]
+    window.scrollTo(x, y)
   }
 
   let unsetScrollRestoration, unlistenScroll, unlistenBefore


### PR DESCRIPTION
current lib/useStandardScroll.js:
    var scrollPosition = getScrollPosition() || [0, 0];
    window.scrollTo.apply(window, scrollPosition);

fixed lib/useStandardScroll.js:
    var x = _ref2[0];
    var y = _ref2[1];

    window.scrollTo(x, y);