### PR TITLE
hash/anchor-link scrolling in standardScroll

### DIFF
--- a/modules/useStandardScroll.js
+++ b/modules/useStandardScroll.js
@@ -27,9 +27,17 @@ export default function useStandardScroll(createHistory) {
 
   // `history` will invoke this listener synchronously, so `currentKey` will
   // always be defined.
-  function updateScroll({ key }) {
+  function updateScroll({ key, hash }) {
     currentKey = key
-
+    if (hash) {
+      // node may not yet be in DOM
+      requestAnimationFrame(() => {
+        const node = document.getElementById(hash.substr(1))
+        if (node) {
+          node.scrollIntoView()
+        }
+      })
+    }
     const [ x, y ] = getScrollPosition() || [ 0, 0 ]
     window.scrollTo(x, y)
   }


### PR DESCRIPTION
I am not certain this is the best approach (basically option 1 from https://github.com/taion/scroll-behavior/issues/22#issue-121245846), but wanted to open something up for discussion.

Changes
-------

- Check for hash and scroll to relevant element on next frame

TODO
--------

- [ ] Do not scroll to hash on POP transition
- [ ] test and account for use with other scrolling libs (e.g., smoothscroll)
- [ ] Tests

Closes #22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/taion/scroll-behavior/47)
<!-- Reviewable:end -->
