### PR TITLE
Support for async transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,24 @@ const history = useScroll(createHistory)({
 })
 ```
 
-### Notes
+#### Async transitions
 
-- Support for async transitions is currently very poor. Fixing this will require major breaking API changes in the future.
+You can defer scroll position update for async transitions (eg. async data loads) by adding a callback to `shouldUpdateScroll`.
+
+```js
+let updateScroll = null
+const history = useScroll(createHistory)({
+  shouldUpdateScroll: (oldLocation, newLocation, cb) => (
+    updateScroll = cb
+  )
+})
+```
+
+After transition is finished, You can notify to update a scroll position by calling the callback with a value same as the return value of `shouldUpdateScroll` explained previously.
+
+```js
+updateScroll(true)
+```
 
 [build-badge]: https://img.shields.io/travis/taion/scroll-behavior/master.svg?style=flat-square
 [build]: https://travis-ci.org/taion/scroll-behavior

--- a/modules/__tests__/describeShouldUpdateScroll.js
+++ b/modules/__tests__/describeShouldUpdateScroll.js
@@ -70,5 +70,33 @@ export default function describeShouldUpdateScroll(useScroll, createHistory) {
         }
       ])
     })
+
+    it('should allow async transition', done => {
+      let shouldUpdateCb = null
+      const history = useScroll(useRoutes(createHistory))({
+        shouldUpdateScroll: (old, current, cb) => {
+          shouldUpdateCb = cb
+        }
+      })
+
+      unlisten = run(history, [
+        () => {
+          history.push('/oldpath')
+        },
+        () => {
+          history.push('/newpath')
+        },
+        () => {
+          expect(scrollLeft(window)).toBe(0)
+          expect(scrollTop(window)).toBe(0)
+          shouldUpdateCb([ 10, 20 ])
+          delay(() => {
+            expect(scrollLeft(window)).toBe(10)
+            expect(scrollTop(window)).toBe(20)
+            done()
+          })
+        }
+      ])
+    })
   })
 }


### PR DESCRIPTION
Fixes #21 

> the way this will work is that shouldUpdateScroll will have an optional async callback, to defer firing until the router renders the new scene.

Is you mean like this?