### PR TITLE
Added history ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dom-helpers": "^2.4.0"
   },
   "peerDependencies": {
-    "history": "^1.12.1 || ^2.0.0"
+    "history": "^1.12.1 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",


### PR DESCRIPTION
Get rid of this annoying warning
```
npm WARN scroll-behavior@0.7.0 requires a peer of history@^1.12.1 || ^2.0.0 but none was installed.
```