### PR TITLE
Add module entry point for Webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",
+  "module": "es/index.js",
   "scripts": {
     "build": "npm run build-cjs && npm run build-es",
     "build-cjs": "rimraf lib && cross-env BABEL_ENV=cjs babel ./src -d lib",


### PR DESCRIPTION
Webpack 2 now prefers "module" entry point for packages with ES modules:
https://github.com/webpack/webpack/commit/dc50c0360e87204ea77172910e877f8c510f3bfb

Similar changes to other popular repos:
reactjs/react-router#3672
reactjs/redux#1871

Rollup is following along:
rollup/rollup-plugin-node-resolve#48

---

For more info see the [Node ES6 Module Interoperability proposal](https://github.com/nodejs/node-eps/blob/master/002-es6-modules.md) and specifically [section 5.1](https://github.com/nodejs/node-eps/blob/master/002-es6-modules.md#51-determining-if-source-is-an-es-module).
