### PR TITLE
Use createHref instead of createPath

### DIFF
--- a/src/ScrollBehavior.js
+++ b/src/ScrollBehavior.js
@@ -156,7 +156,7 @@ export default class ScrollBehavior {
 
   _getKey(location, key) {
     // Use fallback location key when actual location key is unavailable.
-    const locationKey = location.key || this._history.createPath(location);
+    const locationKey = location.key || this._history.createHref(location);
 
     return key == null ?
       `${KEY_PREFIX}${locationKey}` :


### PR DESCRIPTION
createPath is probably supposed to be internal. Since React Router only uses createHref, this minimizes the surface area of history that we use.