### PR TITLE
React-router v3 compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import ScrollBehavior from './scroll-behavior';
+import ScrollBehavior from './ScrollBehavior';
 
 export default function withScroll(history, shouldUpdateScroll) {
   // history will invoke the onChange callback synchronously, so

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,9 @@
-import ScrollBehavior from './ScrollBehavior';
+import ScrollBehavior from './scroll-behavior';
 
 export default function withScroll(history, shouldUpdateScroll) {
   // history will invoke the onChange callback synchronously, so
   // currentLocation will always be defined when needed.
   let currentLocation = null;
-
-  // Unless using react-router v3, that is, so we try and make it work
-  if ({}.hasOwnProperty.call(history, 'getCurrentLocation')) {
-    currentLocation = history.getCurrentLocation();
-  }
 
   function getCurrentLocation() {
     return currentLocation;
@@ -34,6 +29,12 @@ export default function withScroll(history, shouldUpdateScroll) {
         history, getCurrentLocation, shouldUpdateScroll
       );
       unlisten = history.listen(onChange);
+
+      // On react-router/history v3, onChange will not be called on first run
+      let historyV3 = {}.hasOwnProperty.call(history, 'getCurrentLocation');
+      if (historyV3 && !currentLocation) {
+        currentLocation = history.getCurrentLocation();
+      }
     }
 
     listeners.push(listener);

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,11 @@ export default function withScroll(history, shouldUpdateScroll) {
   // currentLocation will always be defined when needed.
   let currentLocation = null;
 
+  // Unless using react-router v3, that is, so we try and make it work
+  if ({}.hasOwnProperty.call(history, 'getCurrentLocation')) {
+    currentLocation = history.getCurrentLocation();
+  }
+
   function getCurrentLocation() {
     return currentLocation;
   }


### PR DESCRIPTION
This "fix" feels like a hack, but it works well to prevent the error `Uncaught TypeError: Cannot read property 'key' of null` when using this library with react-router v3. All tests that passed without the change still do.
