### PR TITLE
Fix for browser style scroll not working in Safari on iOS 10

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,7 @@ export default class ScrollBehavior {
     // scroll it isn't enough. Instead, try to scroll a few times until it
     // works.
     this._numWindowScrollAttempts = 0;
-    requestAnimationFrame(this._checkWindowScrollPosition());
+    requestAnimationFrame(this._checkWindowScrollPosition);
   }
 
   _updateElementScroll(key, prevContext, context) {

--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,7 @@ export default class ScrollBehavior {
     // scroll it isn't enough. Instead, try to scroll a few times until it
     // works.
     this._numWindowScrollAttempts = 0;
-    this._checkWindowScrollPosition();
+    requestAnimationFrame(this._checkWindowScrollPosition());
   }
 
   _updateElementScroll(key, prevContext, context) {


### PR DESCRIPTION
I have just started using https://github.com/taion/react-router-scroll on a project and my team came across a bug when testing in Safari on an iPhone running iOS 10.  The bug does not happen in iOS 9.3.

We are using react router scroll to maintain scroll position when navigating from a detail style page, back to a search page in a single page react app.  React router scroll worked perfectly in all browsers except Safari on iOS 10.  I have done some debugging and traced down where the bug was happening.  

This line of code: https://github.com/taion/scroll-behavior/blob/master/src/index.js#L116 evaluated to true after the first attempt to scroll the window to the correct position.  The scrollTop position of the document was equal to the value that was being attempted to scroll to so no further attempts were made to scroll the page.  The problem is that visually, the page had not scrolled yet.  This seems to be a bug with Safari, it's reporting one scroll position in the document object but was not visually scrolling down the page.

The fix I am proposing to correct this is to use request animation frame for the initial call to `_checkWindowScroll`.  `_checkWindowScrollPosition` calls itself with RAF but the initial call does not use it.  It seems logical to me that the initial call should also use RAF.

Please let me know if you would like me to provide any more details or explanation of this bug and proposed fix.  Thanks!