### PR TITLE
docs($readme): add Complete Example using `history` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ scrollBehavior.registerScrollElement(
 );
 ```
 
+To unregister an element, call the `unregisterElement` method with the key used to register that element.
+
 
 ### Complete Example
 
@@ -193,8 +195,6 @@ export default class SessionStorage {
   }
 }
 ```
-
-To unregister an element, call the `unregisterElement` method with the key used to register that element.
 
 [build-badge]: https://img.shields.io/travis/taion/scroll-behavior/master.svg
 [build]: https://travis-ci.org/taion/scroll-behavior

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pluggable browser scroll management.
 
 **If you're using the latest React Router (v4), feel free to try out its fork: https://github.com/ytase/react-router-scroll. There is one potential issue when using redirects, which may or may not be a problem for you. See ongoing discussion in [#52](https://github.com/taion/react-router-scroll/issues/52).**
 
-**For a redux-first routing solution that makes use of `scroll-behavior`, checkout: [redux-first-router](https://github.com/faceyspacey/redux-first-router).**
+**For a** ***redux-first*** **routing solution that makes use of `scroll-behavior`, checkout: [redux-first-router](https://github.com/faceyspacey/redux-first-router).**
 
 [![Codecov][codecov-badge]][codecov]
 [![Discord][discord-badge]][discord]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pluggable browser scroll management.
 
 **If you use [React Router](https://github.com/reactjs/react-router), use [react-router-scroll](https://github.com/taion/react-router-scroll), which wraps up the scroll management logic here into a React Router middleware.** 
 
-**If you're using the latest React Router (v4), feel free to try out its fork: https://github.com/taion/react-router-scroll. There is one potential issue when using redirects, which may or may not be a problem for you. See ongoing discussion in [#52](https://github.com/taion/react-router-scroll/issues/52).**
+**If you're using the latest React Router (v4), feel free to try out its fork: https://github.com/ytase/react-router-scroll. There is one potential issue when using redirects, which may or may not be a problem for you. See ongoing discussion in [#52](https://github.com/taion/react-router-scroll/issues/52).**
 
 **For a redux-first routing solution that makes use of `scroll-behavior`, checkout: [redux-first-router](https://github.com/faceyspacey/redux-first-router).**
 
@@ -113,7 +113,7 @@ The key element of most the above packages is how `updateScroll` is called in a 
 
 In addition, if your routing library handles data fetching, you likely want to call `updateScroll` again after the data has been fetched and the page re-rendered. This allows `scroll-behavior` to scroll to a portion of the page that might not have loaded before. The same also applies if you're using code-splitting and loading additional chunks. In that case you'll also want to call `updateScroll` after components from the new chunk have rendered.
 
-If your routing library does not handle data fetching, you may want to expose an `updateScroll` function of your own so developers can call it at the appropriate time in userland. Perhaps your users don't want a `<Context />` component constantly re-rendering (even if just in the virtual DOM), and would rather call `updateScroll` in `componentDidUpdate` callbacks that already exist in code. This has the benefit of reducing the amount of rendering work to be done *(cycles add up!)*, which can be key to providing the best experience in large animation-heavy applications.
+If your routing library does not handle data fetching, you may want to expose an `updateScroll` function of your own so developers can call it at the appropriate time in userland. Perhaps your users don't want a `<Context />` component constantly re-rendering (even if just in the virtual DOM), and would rather call `updateScroll` in `componentDidUpdate` callbacks that already exist. This has the benefit of reducing the amount of rendering work to be done *(cycles add up!)*, which can be key to providing the best experience in large animation-heavy applications.
 
 
 [build-badge]: https://img.shields.io/travis/taion/scroll-behavior/master.svg

--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ renderApp(history, scrollBehavior)
 //
 // `scrollBehavior.registerScrollElement(key, element, shouldUpdateScroll, context)`
 ```
-*For an example, look into https://github.com/ytase/react-router-scroll to see how 
+> For an example, look into https://github.com/ytase/react-router-scroll to see how 
 you can create components that use React `context` to pass `scrollBehavior` down 
 your component tree. A similar technique can likely be used for environments other
-than React.*
+than React.
 
 
 *src/createScrollBehavior.js:*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 Pluggable browser scroll management.
 
-**If you use [React Router](https://github.com/reactjs/react-router), use [react-router-scroll](https://github.com/taion/react-router-scroll), which wraps up the scroll management logic here into a React Router middleware.**
+**If you use [React Router](https://github.com/reactjs/react-router), use [react-router-scroll](https://github.com/taion/react-router-scroll), which wraps up the scroll management logic here into a React Router middleware.** 
+
+**If you're using the latest React Router (v4), feel free to try out its fork: https://github.com/taion/react-router-scroll. There is one potential issue when using redirects, which may or may not be a problem for you. See ongoing discussion in [#52](https://github.com/taion/react-router-scroll/issues/52).**
+
+**For a redux-first routing solution that makes use of `scroll-behavior`, checkout: [redux-first-router](https://github.com/faceyspacey/redux-first-router).**
 
 [![Codecov][codecov-badge]][codecov]
 [![Discord][discord-badge]][discord]
@@ -94,107 +98,23 @@ scrollBehavior.registerScrollElement(
 To unregister an element, call the `unregisterElement` method with the key used to register that element.
 
 
-### Complete Example
+### Examples
+This package is typically not used directly, but rather used to power scroll restoration solutions for popular routing libraries. If you're looking to build your own (perhaps for another routing solution), we recommend first checking out the following implementations:
 
-*src/index.js:*
+- https://github.com/taion/react-router-scroll
+- https://github.com/4Catalyzer/found-scroll
+- https://github.com/ytase/react-router-scroll *(React Router v4 fork of `react-router-scroll`; notice how `history.listen` from the popular `history` package is used for `addTransitionHook`)*
+- https://github.com/faceyspacey/redux-first-router-restore-scroll *(shows how to use the  `history` package to configure `scroll-behavior`, but leaves calling `updateScroll` to be handled manually)*
 
-```js
-import createBrowserHistory from 'history/createBrowserHistory'
-import createScrollBehavior from './createScrollBehavior'
-import renderApp from './renderApp'
+The key element of most the above packages is how `updateScroll` is called in a top level `<Context />` component on `componentDidUpdate` when the given router's location has changed:
 
-const history = createBrowserHistory()
-const scrollBehavior = createScrollBehavior(history)
+- https://github.com/taion/react-router-scroll/blob/v0.4.2/src/ScrollBehaviorContext.js#L40-L49
+- https://github.com/4Catalyzer/found-scroll/blob/v0.1.2/src/ScrollManager.js#L35-L44
 
-renderApp(history, scrollBehavior)
-// at this point scrollBehavior won't in fact be needed again if your goal is
-// just to handle window scroll restoration. But if you want other elements
-// throughout your app to have their scroll restored, you will likely want to 
-// pass `scrollBehavior` down your render tree, so you can call:
-//
-// `scrollBehavior.registerScrollElement(key, element, shouldUpdateScroll, context)`
-```
-> For an example, look into https://github.com/ytase/react-router-scroll to see how 
-you can create components that use React `context` to pass `scrollBehavior` down 
-your component tree. A similar technique can likely be used for environments other
-than React.
+In addition, if your routing library handles data fetching, you likely want to call `updateScroll` again after the data has been fetched and the page re-rendered. This allows `scroll-behavior` to scroll to a portion of the page that might not have loaded before. The same also applies if you're using code-splitting and loading additional chunks. In that case you'll also want to call `updateScroll` after components from the new chunk have rendered.
 
+If your routing library does not handle data fetching, you may want to expose an `updateScroll` function of your own so developers can call it at the appropriate time in userland. Perhaps your users don't want a `<Context />` component constantly re-rendering (even if just in the virtual DOM), and would rather call `updateScroll` in `componentDidUpdate` callbacks that already exist in code. This has the benefit of reducing the amount of rendering work to be done *(cycles add up!)*, which can be key to providing the best experience in large animation-heavy applications.
 
-*src/createScrollBehavior.js:*
-```js
-import SessionStorage from './SessionStorage'
-
-let prevContext = null
-let alreadyHandledPathname = null
-
-export default history => {
-  const scrollBehavior = new ScrollBehavior({
-    addTransitionHook: history.listen,
-    stateStorage: new SessionStorage,
-    getCurrentLocation: () => {
-      return {
-        ...history.location,
-        action: history.action // create expected `location` object
-      }
-    },
-    shouldUpdateScroll: (prev, location) => {
-      // perhaps do some custom scroll positioning: 
-      if (location.pathname === 'foo' && prev.pathname === 'bar') {
-        return [0, 300]
-      }
-
-      return true
-    }
-  })
-
-  history.listen(location => {
-    const path = location.pathname
-
-    // usually in systems that listen to address bar changes, the address bar
-    // also changes in response to actions which already handle rendering (e.g.
-    // you manually call `history.push(newPath)`), and as a result shouldn't 
-    // trigger rendering again. Therefore the following rendering is only
-    // triggered in response to pop state events, i.e. where the browser
-    // back/forward buttons were pressed:
-    if (path !== alreadyHandledPathname) {
-      alreadyHandledPathname = path // prevents manual rendering mechanism
-      // do some rendering
-      // e.g: store.dispatch({ type: 'POP_STATE', payload: { path }})
-    }
-
-    scrollBehavior.updateScroll(prevContext, location)
-    prevContext = location
-  })
-
-  return scrollBehavior
-}
-```
-
-
-*src/SessionStorage.js:*
-```js
-const STATE_KEY_PREFIX = '@@scroll|';
-
-export default class SessionStorage {
-  read(location, key) {
-    const stateKey = this.getStateKey(location, key);
-    const value = sessionStorage.getItem(stateKey);
-    return JSON.parse(value);
-  }
-
-  save(location, key, value) {
-    const stateKey = this.getStateKey(location, key);
-    const storedValue = JSON.stringify(value);
-    sessionStorage.setItem(stateKey, storedValue);
-  }
-
-  getStateKey(location, key) {
-    const locationKey = location.key || location.hash;
-    const stateKeyBase = `${STATE_KEY_PREFIX}${locationKey}`;
-    return key == null ? stateKeyBase : `${stateKeyBase}|${key}`;
-  }
-}
-```
 
 [build-badge]: https://img.shields.io/travis/taion/scroll-behavior/master.svg
 [build]: https://travis-ci.org/taion/scroll-behavior


### PR DESCRIPTION
It seems this package and the popular `history` package are perfect companions. Therefore I chose it for the complete example. 

One thing to note: 

`addTransitionHook` should be called "immediately before a transition updates the page" in order to handle this browser deficiency: 

https://github.com/taion/scroll-behavior/blob/master/src/index.js#L102

Yet, the way the `history` package works is that it pushes on the global history state object:
https://github.com/ReactTraining/history/blob/master/modules/createBrowserHistory.js#L172

before it notifies listeners:
https://github.com/ReactTraining/history/blob/master/modules/createBrowserHistory.js#L183

So as a result `addTransitionHook` will be called ***after*** the address bar has updated. This is obviously a problem with the recent [fork for React Router 4](https://github.com/ytase/react-router-scroll) too. Perhaps it's even a problem with `router.listenBefore` used in the original *react-router-scroll* if that simply is a wrapper for `history.listen`. 

Now that said, perhaps all that matters is that the hook is called before the page *rendering*, not the address bar changing. If that's the case, in my example by having `history.listen` passed to `scrollBehavior` and presumably called first, the `history.listen` callback setup at the end of the example, which possibly re-renders the app, should fire after the hook gets a chance to look at it, and before a render that possibly updates the page. Does that satisfy the concerns here?

...I tried to reproduce the issue in Chrome and I don't see the issue (I presume it's because it onlly occurs in older crappier browsers), so I can't easily reproduce it and guarantee that my example addresses it. 

----
The `history` package does not in fact have an `action` key on its `location` objects. It's maintained on the `history` object itself. Let me know what you think about how I addressed that and if it appears the most idiomatic. Ideally only one parameter such as `history` is passed, and `scroll-behavior` looks into it to grab both the `location` and `action`, but obviously this package is already in circulation and that likely is an impossibility. What `location` objects was this originally created for that had `action` keys? The standard browser one has that?? I wonder why the `history` package moved it, or perhaps there's something I'm missing. 


----
Final thing: I noticed in the `react-router-scroll` [PR](https://github.com/taion/react-router-scroll/issues/52) there was some talk about how using `sessionStorage` in combination with redirects (embedded within renders) may cause some problems. I honestly didn't fully understand the issue. It seems it has something to do with the fact that if a page is rendered--even if for just a few milliseconds--before it's redirected from, `scroll-behavior` will do some of its magic to handle browser deficiencies on the wrong page and might do something janky. Basically, `scroll-behavior` expects to do its work on the redirected page. I dunno, but I'm interested in getting to the bottom of it as I'm implementing scroll-restoration using `scroll-behavior` for my *redux-first routing* package: https://github.com/faceyspacey/pure-redux-router .
