### PR TITLE
Fix iOS Safari freeze when swiping to navigate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,18 @@ export default class ScrollBehavior {
     this._getCurrentLocation = getCurrentLocation;
     this._shouldUpdateScroll = shouldUpdateScroll;
 
+    // Unfortunately, Safari on iOS freezes for 2-6s after the user swipes
+    // to navigate through history with scrollRestoration being 'manual',
+    // so we need to detect this browser and exclude it from the following
+    // code until this bug is fixed by Apple.
+    const isMobileSafari = !!navigator.platform &&
+      /iPad|iPhone|iPod/.test(navigator.platform) &&
+      /^((?!chrome|crios).)*safari/i.test(navigator.userAgent);
+
     // This helps avoid some jankiness in fighting against the browser's
     // default scroll behavior on `POP` transitions.
     /* istanbul ignore else: Travis browsers all support this */
-    if ('scrollRestoration' in window.history) {
+    if ('scrollRestoration' in window.history && !isMobileSafari) {
       this._oldScrollRestoration = window.history.scrollRestoration;
       window.history.scrollRestoration = 'manual';
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import scrollTop from 'dom-helpers/query/scrollTop';
 import requestAnimationFrame from 'dom-helpers/util/requestAnimationFrame';
 import invariant from 'invariant';
 
+import { isMobileSafari } from './utils';
+
 // Try at most this many times to scroll, to avoid getting stuck.
 const MAX_SCROLL_ATTEMPTS = 2;
 
@@ -21,18 +23,17 @@ export default class ScrollBehavior {
     this._getCurrentLocation = getCurrentLocation;
     this._shouldUpdateScroll = shouldUpdateScroll;
 
-    // Unfortunately, Safari on iOS freezes for 2-6s after the user swipes
-    // to navigate through history with scrollRestoration being 'manual',
-    // so we need to detect this browser and exclude it from the following
-    // code until this bug is fixed by Apple.
-    const isMobileSafari = !!navigator.platform &&
-      /iPad|iPhone|iPod/.test(navigator.platform) &&
-      /^((?!chrome|crios).)*safari/i.test(navigator.userAgent);
-
     // This helps avoid some jankiness in fighting against the browser's
     // default scroll behavior on `POP` transitions.
     /* istanbul ignore else: Travis browsers all support this */
-    if ('scrollRestoration' in window.history && !isMobileSafari) {
+    if (
+      'scrollRestoration' in window.history &&
+      // Unfortunately, Safari on iOS freezes for 2-6s after the user swipes to
+      // navigate through history with scrollRestoration being 'manual', so we
+      // need to detect this browser and exclude it from the following code
+      // until this bug is fixed by Apple.
+      !isMobileSafari()
+    ) {
       this._oldScrollRestoration = window.history.scrollRestoration;
       window.history.scrollRestoration = 'manual';
     } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,6 @@
+export function isMobileSafari() {
+  return (
+    /iPad|iPhone|iPod/.test(window.navigator.platform) &&
+    /^((?!CriOS).)*Safari/.test(window.navigator.userAgent)
+  );
+}


### PR DESCRIPTION
Fix #128 by not setting scrollRestoration to 'manual' if the current browser is Safari on iOS.