### PR TITLE
fix: always save the initial scroll position even if no scrolling occurs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,13 @@ export default class ScrollBehavior {
       },
     };
 
+    // In case no scrolling occurs, save the initial position
+    if (!scrollElement.savePositionHandle) {
+      scrollElement.savePositionHandle = requestAnimationFrame(
+        saveElementPosition,
+      );
+    }
+
     this._scrollElements[key] = scrollElement;
     on(element, 'scroll', scrollElement.onScroll);
 
@@ -126,6 +133,13 @@ export default class ScrollBehavior {
   }
 
   updateScroll(prevContext, context) {
+    // Save the position immediately after a transition so that if no
+    // scrolling occurs, there is still a saved position
+    if (!this._saveWindowPositionHandle) {
+      this._saveWindowPositionHandle = requestAnimationFrame(
+        this._saveWindowPosition,
+      );
+    }
     this._updateWindowScroll(prevContext, context);
 
     Object.keys(this._scrollElements).forEach(key => {

--- a/test/ScrollBehavior.test.js
+++ b/test/ScrollBehavior.test.js
@@ -141,6 +141,32 @@ describe('ScrollBehavior', () => {
             },
           ]);
         });
+
+        it('should save position even if it does not change', done => {
+          const history = withRoutes(
+            withScroll(createHistory(), (prevLoc, loc) =>
+              loc.action === 'PUSH' ? [10, 20] : true,
+            ),
+          );
+
+          unlisten = run(history, [
+            () => {
+              history.push('/detail');
+            },
+            () => {
+              history.push('/');
+            },
+            () => {
+              history.push('/detail');
+            },
+            () => history.goBack(),
+            () => {
+              expect(scrollLeft(window)).to.equal(10);
+              expect(scrollTop(window)).to.equal(20);
+              done();
+            },
+          ]);
+        });
       });
 
       describe('scroll element', () => {

--- a/test/run.js
+++ b/test/run.js
@@ -1,6 +1,8 @@
 export function delay(cb) {
   // Give throttled scroll listeners time to settle down.
-  requestAnimationFrame(() => requestAnimationFrame(cb));
+  requestAnimationFrame(() =>
+    requestAnimationFrame(() => requestAnimationFrame(cb)),
+  );
 }
 
 export default function run(history, steps) {


### PR DESCRIPTION
Browsers (at least the latest chrome) don't dispatch the `scroll` event unless the scroll position is set to a different value. This gives rise to a bug where if the scroll position is not `[0, 0]` and `shouldUpdateScroll` requests to set the scroll position to what it already is, then the `scroll` event will never happen and the scroll position will not be saved for the new location.

The fix is to save the scroll position immediately after setting it (after a transition) and when adding a scrollable element. At this time the position may not have updated yet, but if it does update then the saved position will be overridden..