### PR TITLE
perf(scroll): use passive listeners for scroll events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,12 +62,13 @@ export default class ScrollBehavior {
       const opts = Object.defineProperty({}, 'passive', {
         get() {
           this._supportsPassive = true;
+          return true;
         },
       });
       window.addEventListener('testPassive', null, opts);
       window.removeEventListener('testPassive', null, opts);
     } catch (e) {
-      
+      return false;
     }
 
     // We have to listen to each window scroll update rather than to just

--- a/src/index.js
+++ b/src/index.js
@@ -62,13 +62,12 @@ export default class ScrollBehavior {
       const opts = Object.defineProperty({}, 'passive', {
         get() {
           this._supportsPassive = true;
-          return true;
         },
       });
       window.addEventListener('testPassive', null, opts);
       window.removeEventListener('testPassive', null, opts);
     } catch (e) {
-      return;
+      
     }
 
     // We have to listen to each window scroll update rather than to just

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ export default class ScrollBehavior {
       window.addEventListener('testPassive', null, opts);
       window.removeEventListener('testPassive', null, opts);
     } catch (e) {
-      return false;
+      this._supportsPassive = false;
     }
 
     // We have to listen to each window scroll update rather than to just


### PR DESCRIPTION
According an article https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners
we currently could use passive listeners for scroll events
here is an example how to detect their avalibility https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md