### PR TITLE
feat: add API to pause scroll position saving

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,9 @@ export default class ScrollBehavior {
 
         // It's fine to save element scroll positions here, though; the browser
         // won't modify them.
-        this._saveElementPosition(key);
+        if (!this._ignoreScrollEvents) {
+          this._saveElementPosition(key);
+        }
       });
     });
   }
@@ -94,13 +96,8 @@ export default class ScrollBehavior {
       shouldUpdateScroll,
       savePositionHandle: null,
 
-      onScroll() {
-        if (this._ignoreScrollEvents) {
-          // Don't save the scroll position until the transition is complete.
-          return;
-        }
-
-        if (!scrollElement.savePositionHandle) {
+      onScroll: () => {
+        if (!scrollElement.savePositionHandle && !this._ignoreScrollEvents) {
           scrollElement.savePositionHandle = requestAnimationFrame(
             saveElementPosition,
           );
@@ -109,7 +106,7 @@ export default class ScrollBehavior {
     };
 
     // In case no scrolling occurs, save the initial position
-    if (!scrollElement.savePositionHandle) {
+    if (!scrollElement.savePositionHandle && !this._ignoreScrollEvents) {
       scrollElement.savePositionHandle = requestAnimationFrame(
         saveElementPosition,
       );

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ export default class ScrollBehavior {
     this._checkWindowScrollHandle = null;
     this._windowScrollTarget = null;
     this._numWindowScrollAttempts = 0;
+
     this._isTransitioning = false;
 
     this._scrollElements = {};
@@ -63,7 +64,8 @@ export default class ScrollBehavior {
     on(window, 'scroll', this._onWindowScroll);
 
     this._removeTransitionHook = addTransitionHook(() => {
-      this.isTransitioning = true;
+      this._isTransitioning = true;
+
       requestAnimationFrame.cancel(this._saveWindowPositionHandle);
       this._saveWindowPositionHandle = null;
 
@@ -80,7 +82,6 @@ export default class ScrollBehavior {
   }
 
   registerElement(key, element, shouldUpdateScroll, context) {
-    const self = this;
     invariant(
       !this._scrollElements[key],
       'ScrollBehavior: There is already an element registered for `%s`.',
@@ -96,10 +97,12 @@ export default class ScrollBehavior {
       shouldUpdateScroll,
       savePositionHandle: null,
 
-      onScroll() {
-        if (self.isTransitioning) {
-          return; // Don't save the scroll position until the transition is complete
+      onScroll: () => {
+        if (this._isTransitioning) {
+          // Don't save the scroll position until the transition is complete.
+          return;
         }
+
         if (!scrollElement.savePositionHandle) {
           scrollElement.savePositionHandle = requestAnimationFrame(
             saveElementPosition,
@@ -139,7 +142,7 @@ export default class ScrollBehavior {
   }
 
   updateScroll(prevContext, context) {
-    this.isTransitioning = false;
+    this._isTransitioning = false;
 
     this._updateWindowScroll(prevContext, context).then(() => {
       // Save the position immediately after a transition so that if no
@@ -177,8 +180,8 @@ export default class ScrollBehavior {
   }
 
   _onWindowScroll = () => {
-    if (this.isTransitioning) {
-      // Don't save the scroll position unil the transition is complete
+    if (this._isTransitioning) {
+      // Don't save the scroll position until the transition is complete.
       return;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,8 +53,7 @@ export default class ScrollBehavior {
     this._checkWindowScrollHandle = null;
     this._windowScrollTarget = null;
     this._numWindowScrollAttempts = 0;
-
-    this._isTransitioning = false;
+    this._ignoreScrollEvents = false;
 
     this._scrollElements = {};
 
@@ -64,8 +63,6 @@ export default class ScrollBehavior {
     on(window, 'scroll', this._onWindowScroll);
 
     this._removeTransitionHook = addTransitionHook(() => {
-      this._isTransitioning = true;
-
       requestAnimationFrame.cancel(this._saveWindowPositionHandle);
       this._saveWindowPositionHandle = null;
 
@@ -97,8 +94,8 @@ export default class ScrollBehavior {
       shouldUpdateScroll,
       savePositionHandle: null,
 
-      onScroll: () => {
-        if (this._isTransitioning) {
+      onScroll() {
+        if (this._ignoreScrollEvents) {
           // Don't save the scroll position until the transition is complete.
           return;
         }
@@ -142,8 +139,6 @@ export default class ScrollBehavior {
   }
 
   updateScroll(prevContext, context) {
-    this._isTransitioning = false;
-
     this._updateWindowScroll(prevContext, context).then(() => {
       // Save the position immediately after a transition so that if no
       // scrolling occurs, there is still a saved position
@@ -179,9 +174,17 @@ export default class ScrollBehavior {
     this._removeTransitionHook();
   }
 
+  startIgnoringScrollEvents() {
+    this._ignoreScrollEvents = true;
+  }
+
+  stopIgnoringScrollEvents() {
+    this._ignoreScrollEvents = false;
+  }
+
   _onWindowScroll = () => {
-    if (this._isTransitioning) {
-      // Don't save the scroll position until the transition is complete.
+    if (this._ignoreScrollEvents) {
+      // Don't save the scroll position until the transition is complete
       return;
     }
 

--- a/test/ScrollBehavior.test.js
+++ b/test/ScrollBehavior.test.js
@@ -278,6 +278,36 @@ describe('ScrollBehavior', () => {
             },
           ]);
         });
+
+        it('should ignore scroll events when startIgnoringScrollEvents is used', done => {
+          const history = withScrollElement(
+            withRoutes(withScroll(createHistory())),
+          );
+
+          unlisten = run(history, [
+            () => {
+              history.startIgnoringScrollEvents();
+              scrollTop(history.container, 5432);
+              delay(() => history.push('/detail'));
+            },
+            () => {
+              delay(() => history.goBack());
+            },
+            () => {
+              expect(scrollTop(history.container)).to.equal(0);
+              history.stopIgnoringScrollEvents();
+              scrollTop(history.container, 2000);
+              delay(() => history.push('/detail'));
+            },
+            () => {
+              delay(() => history.goBack());
+            },
+            () => {
+              expect(scrollTop(history.container)).to.equal(2000);
+              done();
+            },
+          ]);
+        });
       });
     });
   });

--- a/test/ScrollBehavior.test.js
+++ b/test/ScrollBehavior.test.js
@@ -122,6 +122,34 @@ describe('ScrollBehavior', () => {
           ]);
         });
 
+        it('should ignore scroll events when startIgnoringScrollEvents is used', done => {
+          const history = withRoutes(withScroll(createHistory()));
+
+          unlisten = run(history, [
+            () => {
+              history.startIgnoringScrollEvents();
+              scrollTop(window, 5000);
+              delay(() => history.push('/detail'));
+            },
+            () => {
+              delay(() => history.goBack());
+            },
+            () => {
+              expect(scrollTop(window)).to.equal(0);
+              history.stopIgnoringScrollEvents();
+              scrollTop(window, 2000);
+              delay(() => history.push('/detail'));
+            },
+            () => {
+              delay(() => history.goBack());
+            },
+            () => {
+              expect(scrollTop(window)).to.equal(2000);
+              done();
+            },
+          ]);
+        });
+
         it('should allow custom position', done => {
           const history = withRoutes(
             withScroll(createHistory(), () => [10, 20]),

--- a/test/withScroll.js
+++ b/test/withScroll.js
@@ -86,9 +86,19 @@ export default function withScroll(history, shouldUpdateScroll) {
     };
   }
 
+  function startIgnoringScrollEvents() {
+    scrollBehavior.startIgnoringScrollEvents();
+  }
+
+  function stopIgnoringScrollEvents() {
+    scrollBehavior.stopIgnoringScrollEvents();
+  }
+
   return {
     ...history,
     listen,
     registerScrollElement,
+    startIgnoringScrollEvents,
+    stopIgnoringScrollEvents,
   };
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -56,5 +56,9 @@ declare module 'scroll-behavior' {
       element: HTMLElement,
       target: ScrollPosition | string,
     ) => void;
+
+    startIgnoringScrollEvents(): void;
+
+    stopIgnoringScrollEvents(): void;
   }
 }


### PR DESCRIPTION
In [Rudy](https://github.com/respond-framework/rudy) it is possible that `updateScroll` is not called immediately after a transition (rather it might occur asynchronously afterwards).

Further, the content of the new route might not be rendered immediately. for example, the following things might happen
1. transitionHook called to indicate that a transition is about to occur
1. URL changes
1. loading spinner is displayed as the page content
1. asynchronous API request is done
1. final page content is rendered
1. `updateScroll` is called to restore the scroll position on the new route

Sometimes, scroll events happen at steps 3 or 5, because the page content height reduces such that it is lower than the current `window.scrollY` value. In this case, it is not desired to save the scroll position, because it is just noise occurring during the transition.

This adds a flag `_isTransitioning` which is used to skip saving the scroll position in between calls to the transition hook and `updateScroll`. The assumption is that `updateScroll` is **always** called after every transition.