### PR TITLE
fix: avoid using the problematic beforeunload event

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   "homepage": "https://github.com/taion/scroll-behavior#readme",
   "dependencies": {
     "dom-helpers": "^3.4.0",
-    "invariant": "^2.2.4"
+    "invariant": "^2.2.4",
+    "page-lifecycle": "^0.1.2"
   },
   "devDependencies": {
     "@4c/babel-preset": "^7.2.4",

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export default class ScrollBehavior {
     this._stateStorage = stateStorage;
     this._getCurrentLocation = getCurrentLocation;
     this._shouldUpdateScroll = shouldUpdateScroll;
+    this._hasSetScrollRestoration = false;
 
     // This helps avoid some jankiness in fighting against the browser's
     // default scroll behavior on `POP` transitions.
@@ -137,6 +138,10 @@ export default class ScrollBehavior {
   }
 
   _setScrollRestoration = () => {
+    if (this._hasSetScrollRestoration) {
+      // It's possible that the `pageshow` event occurs after we initialise
+      return;
+    }
     if (
       'scrollRestoration' in window.history &&
       // Unfortunately, Safari on iOS freezes for 2-6s after the user swipes to
@@ -154,6 +159,7 @@ export default class ScrollBehavior {
     } else {
       this._oldScrollRestoration = null;
     }
+    this._hasSetScrollRestoration = true;
   };
 
   _restoreScrollRestoration = () => {
@@ -165,6 +171,7 @@ export default class ScrollBehavior {
         /* silence */
       }
     }
+    this._hasSetScrollRestoration = false;
   };
 
   stop() {

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export default class ScrollBehavior {
     this._stateStorage = stateStorage;
     this._getCurrentLocation = getCurrentLocation;
     this._shouldUpdateScroll = shouldUpdateScroll;
+    this._oldScrollRestoration = null;
 
     // This helps avoid some jankiness in fighting against the browser's
     // default scroll behavior on `POP` transitions.
@@ -49,7 +50,6 @@ export default class ScrollBehavior {
     this._windowScrollTarget = null;
     this._numWindowScrollAttempts = 0;
     this._ignoreScrollEvents = false;
-    this._oldScrollRestoration = null;
 
     this._scrollElements = {};
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import scrollLeft from 'dom-helpers/query/scrollLeft';
 import scrollTop from 'dom-helpers/query/scrollTop';
 import requestAnimationFrame from 'dom-helpers/util/requestAnimationFrame';
 import invariant from 'invariant';
+import PageLifecycle from 'page-lifecycle/dist/lifecycle.es5';
 
 import { isMobileSafari } from './utils';
 
@@ -32,8 +33,14 @@ export default class ScrollBehavior {
     // Scroll restoration persists across page reloads. We want to reset
     // this to the original value, so that we can let the browser handle
     // restoring the initial scroll position on server-rendered pages.
-    on(window, 'pagehide', this._restoreScrollRestoration);
-    on(window, 'pageshow', this._setScrollRestoration);
+    PageLifecycle.addEventListener('statechange', ({ oldState, newState }) => {
+      if (newState === 'frozen' || newState === 'terminated') {
+        this._restoreScrollRestoration();
+      }
+      if (oldState === 'frozen') {
+        this._setScrollRestoration();
+      }
+    });
 
     this._saveWindowPositionHandle = null;
     this._checkWindowScrollHandle = null;

--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ export default class ScrollBehavior {
 
   _setScrollRestoration = () => {
     if (this._oldScrollRestoration) {
-      // It's possible that the `pageshow` event occurs after we initialise
+      // It's possible that we already set the scroll restoration
       return;
     }
     if (

--- a/src/index.js
+++ b/src/index.js
@@ -32,11 +32,14 @@ export default class ScrollBehavior {
     // Scroll restoration persists across page reloads. We want to reset
     // this to the original value, so that we can let the browser handle
     // restoring the initial scroll position on server-rendered pages.
-    PageLifecycle.addEventListener('statechange', ({ oldState, newState }) => {
-      if (newState === 'frozen' || newState === 'terminated') {
+    PageLifecycle.addEventListener('statechange', ({ newState }) => {
+      if (
+        newState === 'terminated' ||
+        newState === 'frozen' ||
+        newState === 'discarded'
+      ) {
         this._restoreScrollRestoration();
-      }
-      if (oldState === 'frozen') {
+      } else {
         this._setScrollRestoration();
       }
     });

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,6 @@ export default class ScrollBehavior {
     this._stateStorage = stateStorage;
     this._getCurrentLocation = getCurrentLocation;
     this._shouldUpdateScroll = shouldUpdateScroll;
-    this._hasSetScrollRestoration = false;
 
     // This helps avoid some jankiness in fighting against the browser's
     // default scroll behavior on `POP` transitions.
@@ -47,6 +46,7 @@ export default class ScrollBehavior {
     this._windowScrollTarget = null;
     this._numWindowScrollAttempts = 0;
     this._ignoreScrollEvents = false;
+    this._oldScrollRestoration = null;
 
     this._scrollElements = {};
 
@@ -145,7 +145,7 @@ export default class ScrollBehavior {
   }
 
   _setScrollRestoration = () => {
-    if (this._hasSetScrollRestoration) {
+    if (this._oldScrollRestoration) {
       // It's possible that the `pageshow` event occurs after we initialise
       return;
     }
@@ -163,10 +163,7 @@ export default class ScrollBehavior {
       } catch (e) {
         this._oldScrollRestoration = null;
       }
-    } else {
-      this._oldScrollRestoration = null;
     }
-    this._hasSetScrollRestoration = true;
   };
 
   _restoreScrollRestoration = () => {
@@ -177,8 +174,8 @@ export default class ScrollBehavior {
       } catch (e) {
         /* silence */
       }
+      this._oldScrollRestoration = null;
     }
-    this._hasSetScrollRestoration = false;
   };
 
   stop() {

--- a/test/ScrollBehavior.test.js
+++ b/test/ScrollBehavior.test.js
@@ -25,6 +25,10 @@ describe('ScrollBehavior', () => {
     describe(createHistory.name, () => {
       let unlisten;
 
+      beforeEach(() => {
+        window.history.scrollRestoration = 'auto';
+      });
+
       afterEach(() => {
         if (unlisten) {
           unlisten();

--- a/test/ScrollBehavior.test.js
+++ b/test/ScrollBehavior.test.js
@@ -28,6 +28,23 @@ describe('ScrollBehavior', () => {
         }
       });
 
+      it('pageshow/pagehide', done => {
+        const history = withScroll(createHistory());
+        expect(window.history.scrollRestoration).to.equal('auto');
+        unlisten = run(history, [
+          () => {
+            expect(window.history.scrollRestoration).to.equal('manual');
+            window.dispatchEvent(new Event('pageshow'));
+            expect(window.history.scrollRestoration).to.equal('manual');
+            window.dispatchEvent(new Event('pagehide'));
+            expect(window.history.scrollRestoration).to.equal('auto');
+            window.dispatchEvent(new Event('pageshow'));
+            expect(window.history.scrollRestoration).to.equal('manual');
+            done();
+          },
+        ]);
+      });
+
       describe('default behavior', () => {
         it('should emulate browser scroll behavior', done => {
           const history = withRoutes(withScroll(createHistory()));

--- a/test/ScrollBehavior.test.js
+++ b/test/ScrollBehavior.test.js
@@ -55,8 +55,8 @@ describe('ScrollBehavior', () => {
 
       it('sets/restores scrollRestoration on termination', done => {
         sinon.replace(PageLifecycle, 'addEventListener', setEventListener);
-        const history = withScroll(createHistory());
         expect(window.history.scrollRestoration).to.equal('auto');
+        const history = withScroll(createHistory());
         unlisten = run(history, [
           () => {
             expect(window.history.scrollRestoration).to.equal('manual');

--- a/test/ScrollBehavior.test.js
+++ b/test/ScrollBehavior.test.js
@@ -44,6 +44,8 @@ describe('ScrollBehavior', () => {
         unlisten = run(history, [
           () => {
             expect(window.history.scrollRestoration).to.equal('manual');
+            triggerEvent('frozen', 'hidden');
+            expect(window.history.scrollRestoration).to.equal('manual');
             triggerEvent('hidden', 'frozen');
             expect(window.history.scrollRestoration).to.equal('auto');
             triggerEvent('frozen', 'hidden');

--- a/test/ScrollBehavior.test.js
+++ b/test/ScrollBehavior.test.js
@@ -3,10 +3,11 @@ import scrollLeft from 'dom-helpers/query/scrollLeft';
 import scrollTop from 'dom-helpers/query/scrollTop';
 import createBrowserHistory from 'history/lib/createBrowserHistory';
 import createHashHistory from 'history/lib/createHashHistory';
-import sinon from 'sinon';
 import PageLifecycle from 'page-lifecycle/dist/lifecycle.es5';
+import sinon from 'sinon';
 
 import { createHashHistoryWithoutKey } from './histories';
+import { setEventListener, triggerEvent } from './mockPageLifecycle';
 import {
   withRoutes,
   withScrollElement,
@@ -14,7 +15,6 @@ import {
 } from './routes';
 import run, { delay } from './run';
 import withScroll from './withScroll';
-import { setEventListener, triggerEvent } from './mockPageLifecycle';
 
 describe('ScrollBehavior', () => {
   [

--- a/test/mockPageLifecycle.js
+++ b/test/mockPageLifecycle.js
@@ -1,0 +1,14 @@
+let listener;
+
+export const setEventListener = (eventType, callback) => {
+  listener = callback;
+};
+
+export const triggerEvent = (oldState, newState) => {
+  if (listener) {
+    const event = new Event('statechange');
+    event.newState = newState;
+    event.oldState = oldState;
+    listener(event);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,14 +905,7 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sinonjs/commons@^1":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
-  integrity sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==
-  dependencies:
-    type-detect "4.0.8"
-
-"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0":
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.0.tgz#f90ffc52a2e519f018b13b6c4da03cbff36ebed6"
   integrity sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,7 +905,14 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0":
+"@sinonjs/commons@^1":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
+  integrity sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.0.tgz#f90ffc52a2e519f018b13b6c4da03cbff36ebed6"
   integrity sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==
@@ -5741,6 +5748,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+page-lifecycle@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/page-lifecycle/-/page-lifecycle-0.1.2.tgz#f17a083c082bd5ababddd77f1025a4b1c8808012"
+  integrity sha512-+3uccYgL0CXG0KSXRxZi4uc2E6mqFWV5HqiJJgcnaJCiS0LqiuJ4vB420N21NFuLvuvLB4Jr5drgQ2NXAXF9Iw==
 
 pako@~1.0.5:
   version "1.0.10"


### PR DESCRIPTION
Use of the `beforeunload` event is problematic because when it is used, browsers generally avoid using the back/forward cache or freezing the page, because the (historically assumed) semantics of the `beforeunload` event are incompatible with a page unloading and then loading again. The `unload` event also has this problem, and is not triggered reliably on mobile browsers.

So currently, any site that uses `scroll-behavior` and instantiates it at least once cannot be cached in a browsers back/forward cache, and cannot be frozen to save memory.

See https://developers.google.com/web/updates/2018/07/page-lifecycle-api for details

The `pagehide` and `pageshow` events don't suffer from this problem and are [well supported](https://caniuse.com/#feat=page-transition-events). To use them we must account for the possibility that an unloaded page might be loaded again (e.g. if it was frozen, or put in a browsers back/forward cache).