### PR TITLE
fix: missing ScrollBehavior#stop in index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -57,6 +57,8 @@ declare module 'scroll-behavior' {
       target: ScrollPosition | string,
     ) => void;
 
+    stop(): void;
+
     startIgnoringScrollEvents(): void;
 
     stopIgnoringScrollEvents(): void;


### PR DESCRIPTION
This PR adds missing `ScrollBehavior#stop` in TypeScript declaration file `index.d.ts`.